### PR TITLE
There was a bug that '\n' in csv files were translated into '\\n' in json file.

### DIFF
--- a/LocalizationCSV/Generators/Models/JSON.swift
+++ b/LocalizationCSV/Generators/Models/JSON.swift
@@ -32,7 +32,12 @@ struct JSON {
         for var index = 1; index < csv.grid.count; index++ {
             let row = csv.grid[index]
             let key = row[csv.KeyColumnIndex]
-            let value = row[localeColumnIndex!]
+            var value = row[localeColumnIndex!]
+
+            // Quite weird, but "\n" in NSString is represented as "\\n" when converted to String.
+            if value.containsString("\\n") {
+                value = value.stringByReplacingOccurrencesOfString("\\n", withString: "\n")
+            }
             entries[key] = value
         }
     }


### PR DESCRIPTION
Hello @Cananito 

I encountered a bug where new line character in csv is not exported properly into JSON file. I don't think this ad-hoc approach is the very correct solution, but it will do for the moment. 

Can you quickly merge? 

And in general, do you want to keep maintaining this? Or do you want us to maintain it in C1 lab (or somewhere) as a fork?
